### PR TITLE
Add a lookup function for regions without start or end values

### DIFF
--- a/puretabix/tabix.py
+++ b/puretabix/tabix.py
@@ -177,11 +177,26 @@ class TabixIndex:
                 for chunk in bin_index[chunks_bin_index]:
                     yield chunk
 
+    def _lookup_sequence_min_max(self, sequence_name: str) -> Union[Tuple[None, None], Tuple[int, int]]:
+
+        seq_start = None
+        seq_end = None
+
+        if sequence_name in self.indexes:
+            end_offsets = [item[1] for item in self.indexes[sequence_name][0].items()] ## Collect all values across the bins for this sequence.
+            seq_end = max([max(item) for sublist in end_offsets for item in sublist]) ## Unroll the lists and find the max offset value, representing the end.
+            seq_start = min([min(item) for sublist in end_offsets for item in sublist])
+        
+        return seq_start, seq_end
+
     def lookup_virtual(
         self, sequence_name: str, start: int, end: int
     ) -> Union[Tuple[None, None], Tuple[int, int]]:
         virtual_start = None
         virtual_end = None
+
+        if start is None and end is None:
+            return self._lookup_sequence_min_max(sequence_name)
 
         linear_start = self._lookup_linear(sequence_name, start)
         # if this is not in the linear index, cant return anything

--- a/puretabix/tabix.py
+++ b/puretabix/tabix.py
@@ -255,6 +255,12 @@ class TabixIndex:
                 outfile.write(struct.pack("<Q", ioff))
 
     @classmethod
+    def get_contigs(cls):
+        assert cls.indexes is not None
+        return list(cls.indexes.keys())
+
+
+    @classmethod
     def build_from(cls, rawfile) -> "TabixIndex":
         """
         read a vcf file in blockgzip format and create an index object for it

--- a/puretabix/tabix.py
+++ b/puretabix/tabix.py
@@ -571,7 +571,8 @@ class TabixIndexedVCFFile(TabixIndexedFile):
             xdat.extend(data)
             last_line_location = re.search("#CHROM.*\n", xdat.decode())  ## Search until the VCF sample line.
         
-        self.bgzipped.seek(current_position)
+        self.bgzipped.seek(current_position) ## reset file pointer to original position
+        
         return last_line_location.string[:last_line_location.end(0)]  ## Slice the string to just the header.
 
     def fetch_vcf_lines(

--- a/puretabix/tabix.py
+++ b/puretabix/tabix.py
@@ -551,28 +551,27 @@ class TabixIndexedVCFFile(TabixIndexedFile):
         self.vcf_fsm = get_vcf_fsm()
         self.accumulator = VCFAccumulator()
 
-    @classmethod
-    def fetch_vcf_header(cls):
+    def fetch_vcf_header(self):
         """
         Return the header of a VCF file as a string.
         """
-        assert cls.bgzipp is not None
-        
-        current_position = cls.bgzipped.tell()
+        assert self.bgzipped is not None
 
-        if (not cls.bgzipped.check_is_block_gzip()):  ## Note: this moves the file pointer. Must call seek to return to 0.
+        current_position = self.bgzipped.tell()
+
+        if (not self.bgzipped.check_is_block_gzip()):  ## Note: this moves the file pointer. Must call seek to return to 0.
             raise Exception("Indexed file must be block-gzipped.")
 
-        cls.bgzipped.seek(0)  ## Reset to start of file.
+        self.bgzipped.seek(0)  ## Reset to start of file.
 
         xdat = bytearray()
         last_line_location = None  ## Will store an re.match object, terminating the loop when the last header line is found.
         while not last_line_location:
-            _, _, data, _ = cls.bgzipped.get_block()  ## Read the next block from the file.
+            _, _, data, _ = self.bgzipped.get_block()  ## Read the next block from the file.
             xdat.extend(data)
             last_line_location = re.search("#CHROM.*\n", xdat.decode())  ## Search until the VCF sample line.
         
-        cls.bgzipped.seek(current_position) ## reset file pointer to original position
+        self.bgzipped.seek(current_position) ## reset file pointer to original position
 
         return last_line_location.string[:last_line_location.end(0)]  ## Slice the string to just the header.
 

--- a/puretabix/tabix.py
+++ b/puretabix/tabix.py
@@ -551,28 +551,29 @@ class TabixIndexedVCFFile(TabixIndexedFile):
         self.vcf_fsm = get_vcf_fsm()
         self.accumulator = VCFAccumulator()
 
-    def fetch_vcf_header(self):
+    @classmethod
+    def fetch_vcf_header(cls):
         """
         Return the header of a VCF file as a string.
         """
-        assert self.vcf_path is not None
+        assert cls.vcf_path is not None
 
-        current_position = self.bgzipped.tell()
+        current_position = cls.bgzipped.tell()
 
-        if (not self.bgzipped.check_is_block_gzip()):  ## Note: this moves the file pointer. Must call seek to return to 0.
+        if (not cls.bgzipped.check_is_block_gzip()):  ## Note: this moves the file pointer. Must call seek to return to 0.
             raise Exception("Indexed file must be block-gzipped.")
 
-        self.bgzipped.seek(0)  ## Reset to start of file.
+        cls.bgzipped.seek(0)  ## Reset to start of file.
 
         xdat = bytearray()
         last_line_location = None  ## Will store an re.match object, terminating the loop when the last header line is found.
         while not last_line_location:
-            _, _, data, _ = self.bgzipped.get_block()  ## Read the next block from the file.
+            _, _, data, _ = cls.bgzipped.get_block()  ## Read the next block from the file.
             xdat.extend(data)
             last_line_location = re.search("#CHROM.*\n", xdat.decode())  ## Search until the VCF sample line.
         
-        self.bgzipped.seek(current_position) ## reset file pointer to original position
-        
+        cls.bgzipped.seek(current_position) ## reset file pointer to original position
+
         return last_line_location.string[:last_line_location.end(0)]  ## Slice the string to just the header.
 
     def fetch_vcf_lines(

--- a/puretabix/tabix.py
+++ b/puretabix/tabix.py
@@ -556,8 +556,8 @@ class TabixIndexedVCFFile(TabixIndexedFile):
         """
         Return the header of a VCF file as a string.
         """
-        assert cls.vcf_path is not None
-
+        assert cls.bgzipp is not None
+        
         current_position = cls.bgzipped.tell()
 
         if (not cls.bgzipped.check_is_block_gzip()):  ## Note: this moves the file pointer. Must call seek to return to 0.


### PR DESCRIPTION
This MR adds a function that can return the virtual offsets for a region query that consists only of a sequence name. This function is then called when `None` is passed for both the start and end coordinates to `lookup_virtual`:

```python
tbi = puretabix.TabixIndexedVCFFile.from_files(open("example.vcf.gz", "rb"), open("example.vcf.gz.tbi", "rb"))

tbi.index._lookup_sequence_min_max("chr1")
tbi.index.lookup_virtual("chr1", None, None)
```
```
(0, 2559311872)
(0, 2559311872)
```

The performance of this function is probably suboptimal for large VCFs, however I've tested files with a few thousand bins with no issue and it should grow more or less linearly with the bin count.