### PR TITLE
ignore build folder

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,3 +12,4 @@ dist
 test-reports/
 tests/perf_test.txt
 .DS_store
+build


### PR DESCRIPTION
Minor change to ignore files built during package release process so they don't get added to Git accidentally.