### PR TITLE
add vcf header option

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -1,3 +1,4 @@
+5.4.0, 2023/12/02 -- Add header-only VCF parser function
 5.3.3, 2023/02/12 -- Fix index generation
 5.3.2, 2023/01/04 -- Fix broken release again
 5.3.1, 2023/01/04 -- Fix broken release

--- a/puretabix/vcf.py
+++ b/puretabix/vcf.py
@@ -692,15 +692,25 @@ def get_vcf_fsm():
     return fsm_vcf
 
 
-def read_vcf_lines(input: Iterable[str]) -> Generator[VCFLine, None, None]:
+def read_vcf_lines(
+    input_: Iterable[str], header_only: bool = False
+) -> Generator[VCFLine, None, None]:
     """
     Convenience function for parsing a source of VCF lines
     """
     vcf_fsm = get_vcf_fsm()
     accumulator = VCFAccumulator()
-    for line in input:
+    for line in input_:
         if line:
             vcf_fsm.run(line, LINE_START, accumulator)
             vcfline = accumulator.to_vcfline()
             accumulator.reset()
+
+            # if we only want to get the initial header
+            # and this is not part of the header
+            # then stop
+            # Note: this does include the vcf column headings (sample names)
+            if not vcfline.is_comment and header_only:
+                break
+
             yield vcfline

--- a/tests/vcf_test.py
+++ b/tests/vcf_test.py
@@ -54,8 +54,6 @@ class TestVCFFSM:
 
         for line_in, line_out in zip(lines, lines_parsed):
             line_in = line_in.strip()
-            print(line_in)
-            print(str(line_out).strip())
             assert line_in == str(line_out), (line_in, line_out)
 
     def test_dbsnp_gt(self, vcf_gz):
@@ -64,7 +62,14 @@ class TestVCFFSM:
 
         for line_in, line_out in zip(lines, lines_parsed):
             line_in = line_in.strip()
-            print(line_in)
-            print(str(line_out).strip())
             if not line_out.is_comment:
                 assert line_out.get_genotype()
+
+    def test_dbsnp_header(self, vcf_gz):
+        lines = tuple(map(bytes.decode, vcf_gz.readlines()))
+        lines_parsed = read_vcf_lines(lines, header_only=True)
+
+        for line_in, line_out in zip(lines, lines_parsed):
+            line_in = line_in.strip()
+            assert line_out.is_comment
+            assert str(line_out).startswith("#")


### PR DESCRIPTION
Adds an option to only parse the header from a VCF file and then stop. Very useful to verify a file is what you think it is before trying to read the entire thing.