### PR TITLE
fix empty info as dot

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -21,6 +21,7 @@ repos:
     hooks:
       - id: mypy
         args: [--strict, --ignore-missing-imports]
+        files: puretabix/
   - repo: https://github.com/pre-commit/pre-commit-hooks
     rev: v2.4.0
     hooks:

--- a/puretabix/vcf.py
+++ b/puretabix/vcf.py
@@ -156,6 +156,8 @@ class VCFLine:
                             f"{key}={','.join(value)}" if value else key
                             for key, value in self.info.items()
                         )
+                        if self.info
+                        else "."
                     ),
                 )
             )

--- a/tests/vcf_test.py
+++ b/tests/vcf_test.py
@@ -46,6 +46,26 @@ class TestVCFLineConstructors:
             == "VCFLine('','','',{},'chr1',123,('rs1',),'A',('C',),'.',('PASS',),{'foo': 'bar'},({'GT': '1/1'}, {'GT': '1/1'}))"
         )
 
+    def test_data_empty_info(self):
+        line = VCFLine.as_data(
+            "chr1",
+            123,
+            ["rs1"],
+            "A",
+            ["C"],
+            ".",
+            ["PASS"],
+            {},
+            [{"GT": "1/1"}, {"GT": "1/1"}],
+        )
+        linestr = str(line)
+        assert linestr == "chr1\t123\trs1\tA\tC\t.\tPASS\t.\tGT\t1/1\t1/1"
+        linerepr = repr(line)
+        assert (
+            linerepr
+            == "VCFLine('','','',{},'chr1',123,('rs1',),'A',('C',),'.',('PASS',),{},({'GT': '1/1'}, {'GT': '1/1'}))"
+        )
+
 
 class TestVCFFSM:
     def test_dbsnp(self, vcf_gz):


### PR DESCRIPTION
Fix issue where an empty dict passed to info should be rendered as a dot character but is instead rendered as an empty column. Also adds a test for this.

Additionally, a minor fix to ensure precomit mypy checks are only run on the module and not any test changes. 